### PR TITLE
fix(vartime_double_base): remove usage of alloc

### DIFF
--- a/curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/variable_base.rs
@@ -5,8 +5,6 @@ use crate::edwards::EdwardsPoint;
 use crate::scalar::Scalar;
 use crate::traits::Identity;
 use crate::window::LookupTable;
-use alloc::vec::Vec;
-use crate::constants::ED25519_BASEPOINT_POINT;
 
 #[cfg(not(all(target_os = "zkvm", target_vendor = "succinct")))]
 /// Perform constant-time, variable-base scalar multiplication.

--- a/curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs
@@ -86,8 +86,8 @@ use sp1_lib::{ed25519::Ed25519AffinePoint, utils::AffinePoint};
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
     let A: Ed25519AffinePoint = (*A).into();
 
-    let a_bits = a.bits_le_slice();
-    let b_bits = b.bits_le_slice();
+    let a_bits = a.bits_le_array();
+    let b_bits = b.bits_le_array();
 
     // Note: The base point is the identity point.
     let res = AffinePoint::multi_scalar_multiplication(

--- a/curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs
+++ b/curve25519-dalek/src/backend/serial/scalar_mul/vartime_double_base.rs
@@ -18,8 +18,10 @@ use crate::edwards::EdwardsPoint;
 use crate::scalar::Scalar;
 use crate::traits::Identity;
 use crate::window::NafLookupTable5;
-use alloc::vec::Vec;
+
+#[cfg(not(feature = "precomputed-tables"))]
 use crate::constants::ED25519_BASEPOINT_POINT;
+
 
 #[cfg(not(all(target_os = "zkvm", target_vendor = "succinct")))]
 /// Compute \\(aA + bB\\) in variable time, where \\(B\\) is the Ed25519 basepoint.
@@ -84,15 +86,15 @@ use sp1_lib::{ed25519::Ed25519AffinePoint, utils::AffinePoint};
 pub fn mul(a: &Scalar, A: &EdwardsPoint, b: &Scalar) -> EdwardsPoint {
     let A: Ed25519AffinePoint = (*A).into();
 
-    let a_bits = a.bits_le().collect::<Vec<bool>>();
-    let b_bits = b.bits_le().collect::<Vec<bool>>();
+    let a_bits = a.bits_le_slice();
+    let b_bits = b.bits_le_slice();
 
     // Note: The base point is the identity point.
     let res = AffinePoint::multi_scalar_multiplication(
         &a_bits,
         A,
         &b_bits,
-        ED25519_BASEPOINT_POINT.into(),
+        crate::constants::ED25519_BASEPOINT_POINT.into(),
     )
     .unwrap();
     res.into()

--- a/curve25519-dalek/src/scalar.rs
+++ b/curve25519-dalek/src/scalar.rs
@@ -845,9 +845,9 @@ impl Scalar {
         (0..256).map(move |i| self.get_bit_le(i))
     }
 
+    /// Get the bits of the scalar, in little-endian order, as an array
     #[cfg(all(target_os = "zkvm", target_vendor = "succinct"))]
-    /// Get the bits of the scalar, in little-endian order, as a slice
-    pub(crate) fn bits_le_slice(&self) -> [bool; 256] {
+    pub(crate) fn bits_le_array(&self) -> [bool; 256] {
         let mut bits = [false; 256];
         for i in 0..256 {
             bits[i] = self.get_bit_le(i);


### PR DESCRIPTION
We replaced the usage of `alloc::Vec`, with a constant-sized slice.